### PR TITLE
Fix stdpipe bugs

### DIFF
--- a/elcord.el
+++ b/elcord.el
@@ -158,7 +158,7 @@ Unused on other platforms.")
                 "-NoProfile"
                 "-ExecutionPolicy" "Bypass"
                 "-Command" elcord--stdpipe-path "." elcord--discord-ipc-pipe)
-      :connection-type nil
+      :connection-type 'pipe
       :sentinel 'elcord--connection-sentinel
       :filter 'elcord--connection-filter
       :noquery nil))


### PR DESCRIPTION
* With a connection-type of 'nil the process may be created using a pty. In such a case, EOF is occasionally sent by emacs which causes stdpipe to busy loop forever.
    This made Discord not update, while also eating up the CPU
* Completely re-do stdpipe as embedded csharp to get around issues with stdin:
  * Console.In is a TextReader that is specifically designed to block on its IO operations, even ReadAsync
    To get around this, OpenStandardInput was being used instead. This however caused us to 'Miss' any input already on there. And we can't call Console.In.Read* to get it because those all block on no input
  * Instead, the cleanest way is to specifically read Stdin on a separate thread, but doing this from PowerShell was something I simply could not figure out. Hence the embedded csharp.

In essence the embedded csharp does the exact same thing the PowerShell used to do, except it reads stdin from a background thread instead.