### PR TITLE
Add support for meson-mode

### DIFF
--- a/elcord.el
+++ b/elcord.el
@@ -75,6 +75,7 @@ See <https://discordapp.com/developers/applications/me>."
                                     (lisp-mode . "lisp-mode_icon")
                                     (magit-mode . "magit-mode_icon")
                                     (markdown-mode . "markdown-mode_icon")
+                                    (meson-mode . "meson-mode_icon")
                                     (nix-mode . "nix-mode_icon")
                                     (org-mode . "org-mode_icon")
                                     (racket-mode . "racket-mode_icon")


### PR DESCRIPTION
Adds support for editing meson.build files.

Here's a copy of the Meson logo that I cropped out from the [repository](https://github.com/mesonbuild/meson/blob/master/graphics/meson_logo.svg) (had to zip it, Github doesn't support attaching SVG files directly).

[meson_logo.zip](https://github.com/Mstrodl/elcord/files/6510644/meson_logo.zip)
