### PR TITLE
Added project name display using projectile

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,8 @@ For creating an 'Application':
 
 After you've created your application, Customize `elcord-client-id` to be the new application's client ID,
 and set the value of `elcord-mode-icon-alist` as appropriate to reference your new icons.
+
+## Projectile Integration
+
+elcord supports displaying which project you're currently working on by using [Projectile](https://github.com/bbatsov/projectile). Simply make sure that projectile is loaded before elcord, and enable the "Elcord Display Project Name" custimization via `M-x package-install RET elcord RET`, or `(setq elcord-display-project-name t)`.
+Please note that line numbers and the project name cannot be displayed at the same time. Displaying line numbers will take precedence if both have been enabled.

--- a/elcord.el
+++ b/elcord.el
@@ -195,6 +195,16 @@ The mode text is the same found by `elcord-mode-text-alist'"
   :type 'boolean
   :group 'elcord)
 
+(defcustom elcord-display-project-name 't
+  "When enabled, Discord status will display the project name the current buffer is part of:
+\"Editing <buffer-name>\"
+  \"Working on <project-name>\"
+
+When both elcord-display-line-numbers and elcord-display-project-name are enabled, displaying line numbers takes
+presenence.
+
+Requires Projectile.")
+
 (defcustom elcord-display-line-numbers 't
   "When enabled, shows the total line numbers of current buffer.
 Including the position of the cursor in the buffer."
@@ -204,6 +214,12 @@ Including the position of the cursor in the buffer."
 (defcustom elcord-buffer-details-format-function 'elcord-buffer-details-format
   "Function to return the buffer details string shown on discord.
 Swap this with your own function if you want a custom buffer-details message."
+  :type 'function
+  :group 'elcord)
+
+(defcustom elcord-project-name-format-function 'elcord-project-name-format
+  "Function to return the project name string shown on discord.
+Swap this with your own function if you want a custom project-name message."
   :type 'function
   :group 'elcord)
 
@@ -287,6 +303,9 @@ Unused on other platforms.")
 
 (defvar elcord--idle-status nil
   "Current idle status.")
+
+(defvar elcord--projectile-present (when (require 'projectile nil 'noerror) t)
+  "Whether projectile is present or not.")
 
 (defun elcord--make-process ()
   "Make the asynchronous process that communicates with Discord IPC."
@@ -578,18 +597,25 @@ If no text is available, use the value of `mode-name'."
   "Return the buffer details string shown on discord."
   (format "Editing %s" (buffer-name)))
 
+(defun elcord-project-name-format ()
+  "Return the project name as shown on discord."
+  (format "Working on %s" (projectile-project-name)))
+
 (defun elcord--details-and-state ()
   "Obtain the details and state to use for Discord's Rich Presence."
   (let ((activity (list
                    (if elcord-display-buffer-details
                        (cons "details" (funcall elcord-buffer-details-format-function))
                      (cons "details" "Editing")))))
-
-    (when elcord-display-line-numbers
-      (push (cons "state" (format "Line %s of %S"
-                                        (format-mode-line "%l")
-                                        (+ 1 (count-lines (point-min) (point-max)))))
-            activity))
+    
+    (if elcord-display-line-numbers
+        (push (cons "state" (format "Line %s of %S"
+                                    (format-mode-line "%l")
+                                    (+ 1 (count-lines (point-min) (point-max)))))
+              activity)
+      (when (and elcord-display-project-name elcord--projectile-present (not (string= (projectile-project-name) "-")))
+        (push (cons "state" (funcall elcord-project-name-format-function)) activity)))
+      
     (when elcord-display-elapsed
       (push (list "timestamps" (cons "start" elcord--startup-time)) activity))
     activity))

--- a/elcord.el
+++ b/elcord.el
@@ -580,18 +580,16 @@ If no text is available, use the value of `mode-name'."
 
 (defun elcord--details-and-state ()
   "Obtain the details and state to use for Discord's Rich Presence."
-  (let ((activity (if elcord-display-buffer-details
-                      (if elcord-display-line-numbers
-                          (list
-                           (cons "details" (funcall elcord-buffer-details-format-function))
-                           (cons "state" (format "Line %s of %S"
-                                                 (format-mode-line "%l")
-                                                 (+ 1 (count-lines (point-min) (point-max))))))
-                        (list
-                         (cons "details" (funcall elcord-buffer-details-format-function))))
-                    (list
-                     (cons "details" "Editing")
-                     (cons "state" (elcord--mode-text))))))
+  (let ((activity (list
+                   (if elcord-display-buffer-details
+                       (cons "details" (funcall elcord-buffer-details-format-function))
+                     (cons "details" "Editing")))))
+
+    (when elcord-display-line-numbers
+      (push (cons "state" (format "Line %s of %S"
+                                        (format-mode-line "%l")
+                                        (+ 1 (count-lines (point-min) (point-max)))))
+            activity))
     (when elcord-display-elapsed
       (push (list "timestamps" (cons "start" elcord--startup-time)) activity))
     activity))

--- a/elcord.el
+++ b/elcord.el
@@ -201,7 +201,7 @@ The mode text is the same found by `elcord-mode-text-alist'"
   \"Working on <project-name>\"
 
 When both elcord-display-line-numbers and elcord-display-project-name are enabled, displaying line numbers takes
-presenence.
+precedence.
 
 Requires Projectile.")
 


### PR DESCRIPTION
I've added a completely optional feature allowing users to display the name of the project the current buffer is in by using projectile. Projectile is a completely optional dependency here.

![image](https://github.com/Mstrodl/elcord/assets/36799498/1d905f4c-f1c3-4231-adc8-a134c053b3e2)

I've also changed the `elcord--details-and-state` function so that future additions would be easier.