### PR TITLE
Fix ‘make-network-process’ warning by adding missing :service argument

### DIFF
--- a/elcord.el
+++ b/elcord.el
@@ -340,6 +340,7 @@ Unused on other platforms.")
        (make-network-process
         :name "*elcord-sock*"
         :remote (elcord--find-discord-ipc-pipe)
+        :service nil
         :sentinel 'elcord--connection-sentinel
         :filter 'elcord--connection-filter
         :noquery t)))))


### PR DESCRIPTION
### Summary
Fixes the following warning:

 - Warning (bytecomp): ‘make-network-process´ called without required keyword argument :service

### Details
- Added `:service nil` to resolve the warning.